### PR TITLE
fix build on macOS

### DIFF
--- a/bench/bench.cpp
+++ b/bench/bench.cpp
@@ -25,7 +25,8 @@ int main(int argc, char **argv) {
     double t0 = now();
     auto res = ingest_tarball_file(store, argv[i]);
     double dt = now() - t0;
-    printf("ingest     %8lu files in %6.2fs (%.0f files/s)\n", res.files, dt,
+    printf("ingest     %8llu files in %6.2fs (%.0f files/s)\n",
+           static_cast<unsigned long long>(res.files), dt,
            res.files / dt);
     root = res.root;
   }

--- a/fuzz/fuzz_ingest.cc
+++ b/fuzz/fuzz_ingest.cc
@@ -1,5 +1,6 @@
 // libFuzzer target: arbitrary bytes as tarball -> ingest must never crash,
 // and everything ingested must be readable back.
+#include "../tests/test_tmp.hpp"
 #include "tree.hpp"
 
 #include <archive.h>
@@ -14,10 +15,7 @@ namespace {
 
 TreeStore &store() {
   static std::unique_ptr<TreeStore> s = [] {
-    std::string dir = "/tmp/tarmac-fuzz-" + std::to_string(getpid());
-    std::string cmd = "rm -rf " + dir;
-    if (system(cmd.c_str()) != 0)
-      abort();
+    std::string dir = make_test_dir("tarmac-fuzz");
     return std::make_unique<TreeStore>(PackCas::open(dir));
   }();
   return *s;

--- a/src/pack_cas.cpp
+++ b/src/pack_cas.cpp
@@ -42,6 +42,14 @@ auto blake3_hash(std::string_view data) -> std::string {
 
 namespace {
 
+auto data_sync(int fd) -> int {
+#ifdef __APPLE__
+  return fcntl(fd, F_BARRIERFSYNC);
+#else
+  return fdatasync(fd);
+#endif
+}
+
 constexpr size_t kMapSize = 1UL << 40;
 constexpr size_t kIndexMapSize = 32UL << 30;
 constexpr uint64_t kAutoSyncBytes = 256UL << 20;
@@ -427,7 +435,7 @@ struct PackCas::Impl {
 
   void commit_batch() {
     auto mapping = current();
-    if (fdatasync(mapping->pack_fd) < 0) {
+    if (data_sync(mapping->pack_fd) < 0) {
       sys_err("fdatasync pack");
     }
     mdb_check(mdb_txn_commit(wtxn), "txn_commit");
@@ -732,7 +740,7 @@ void PackCas::compact(const std::function<bool(std::string_view)> &live) {
     }
     mdb_cursor_close(cursor);
     write_all(new_fd, buf);
-    if (fdatasync(new_fd) < 0) {
+    if (data_sync(new_fd) < 0) {
       sys_err("fdatasync new pack");
     }
 

--- a/tests/corrupt_test.cpp
+++ b/tests/corrupt_test.cpp
@@ -1,4 +1,6 @@
 // corruption test: truncated/flipped pack must error or misread, never crash
+#include "test_tmp.hpp"
+
 #include "pack_cas.hpp"
 
 #include <fcntl.h>
@@ -10,10 +12,7 @@
 #include <vector>
 
 int main(int argc, char **argv) {
-  std::string dir = argc > 1 ? argv[1] : "/tmp/packcas-corrupt-test";
-  std::string cmd = "rm -rf " + dir;
-  if (system(cmd.c_str()) != 0)
-    return 1;
+  std::string dir = argc > 1 ? argv[1] : make_test_dir("packcas-corrupt-test");
 
   std::mt19937_64 rng(7);
   std::vector<std::string> hashes;
@@ -71,10 +70,7 @@ int main(int argc, char **argv) {
 
   // truncation while the store is open: get() must throw, never SIGBUS
   {
-    std::string dir2 = dir + "-live";
-    std::string cmd2 = "rm -rf " + dir2;
-    if (system(cmd2.c_str()) != 0)
-      return 1;
+    std::string dir2 = dir + "/live";
     auto cas = PackCas::open(dir2);
     std::vector<std::string> hs;
     for (int i = 0; i < 100; i++)
@@ -97,10 +93,7 @@ int main(int argc, char **argv) {
 
   // trashed index: open() must wipe and start fresh
   {
-    std::string dir3 = dir + "-heal";
-    std::string cmd3 = "rm -rf " + dir3;
-    if (system(cmd3.c_str()) != 0)
-      return 1;
+    std::string dir3 = dir + "/heal";
     {
       auto cas = PackCas::open(dir3);
       (void) cas->put("hello");

--- a/tests/crash_test.cpp
+++ b/tests/crash_test.cpp
@@ -1,5 +1,7 @@
 // multi-process safety: concurrent writers must not lose data, and a
 // SIGKILLed writer must never corrupt the store or lose synced batches
+#include "test_tmp.hpp"
+
 #include "tree.hpp"
 
 #include <fcntl.h>
@@ -118,10 +120,7 @@ void crash_recovery(const std::string &dir) {
 } // namespace
 
 int main(int argc, char **argv) {
-  std::string dir = argc > 1 ? argv[1] : "/tmp/packcas-crash-test";
-  std::string cmd = "rm -rf " + dir;
-  if (system(cmd.c_str()) != 0)
-    return 1;
+  std::string dir = argc > 1 ? argv[1] : make_test_dir("packcas-crash-test");
   concurrent_writers(dir);
   crash_recovery(dir);
   return 0;

--- a/tests/crash_test.cpp
+++ b/tests/crash_test.cpp
@@ -16,6 +16,14 @@
 
 namespace {
 
+int data_sync(int fd) {
+#ifdef __APPLE__
+  return fcntl(fd, F_BARRIERFSYNC);
+#else
+  return fdatasync(fd);
+#endif
+}
+
 std::string blob_for(unsigned child, unsigned i) {
   std::string b = "child-" + std::to_string(child) + "-" + std::to_string(i);
   b.resize(100 + (i * 37) % 5000, static_cast<char>('a' + child));
@@ -73,7 +81,7 @@ void killer(const std::string &dir, const std::string &log, uint64_t seed) {
         for (auto &h : batch)
           fprintf(f, "%s\n", to_hex(h).c_str());
         fflush(f);
-        assert(fdatasync(fileno(f)) == 0);
+        assert(data_sync(fileno(f)) == 0);
         batch.clear();
       }
     }

--- a/tests/gc_test.cpp
+++ b/tests/gc_test.cpp
@@ -1,4 +1,6 @@
 // TTL eviction over roots plus mark-and-sweep compaction
+#include "test_tmp.hpp"
+
 #include "tree.hpp"
 
 #include <archive.h>
@@ -53,10 +55,7 @@ IngestResult ingest(TreeStore &store, unsigned id) {
 } // namespace
 
 int main(int argc, char **argv) {
-  std::string dir = argc > 1 ? argv[1] : "/tmp/packcas-gc-test";
-  std::string cmd = "rm -rf " + dir;
-  if (system(cmd.c_str()) != 0)
-    return 1;
+  std::string dir = argc > 1 ? argv[1] : make_test_dir("packcas-gc-test");
 
   constexpr auto kTtl = std::chrono::milliseconds(200);
   constexpr auto kNoDelay = std::chrono::nanoseconds(0);

--- a/tests/model_test.cpp
+++ b/tests/model_test.cpp
@@ -1,4 +1,6 @@
 // randomized model test: PackCas vs in-memory map, with reopen cycles
+#include "test_tmp.hpp"
+
 #include "pack_cas.hpp"
 
 #include <cassert>
@@ -11,11 +13,8 @@
 #include <vector>
 
 int main(int argc, char **argv) {
-  std::string dir = argc > 1 ? argv[1] : "/tmp/packcas-model-test";
+  std::string dir = argc > 1 ? argv[1] : make_test_dir("packcas-model-test");
   uint64_t seed = argc > 2 ? std::stoull(argv[2]) : 1;
-  std::string cmd = "rm -rf " + dir;
-  if (system(cmd.c_str()) != 0)
-    return 1;
 
   std::mt19937_64 rng(seed);
   std::unordered_map<std::string, std::string> model;

--- a/tests/nar_test.cpp
+++ b/tests/nar_test.cpp
@@ -1,4 +1,6 @@
 // golden test: NAR hash must match `nix hash path` for a known tree
+#include "test_tmp.hpp"
+
 #include "tree.hpp"
 
 #include <archive.h>
@@ -34,10 +36,7 @@ void add_entry(archive *a, const char *path, mode_t type, mode_t perm,
 } // namespace
 
 int main(int argc, char **argv) {
-  std::string dir = argc > 1 ? argv[1] : "/tmp/packcas-nar-test";
-  std::string cmd = "rm -rf " + dir;
-  if (system(cmd.c_str()) != 0)
-    return 1;
+  std::string dir = argc > 1 ? argv[1] : make_test_dir("packcas-nar-test");
 
   std::string tar;
   {

--- a/tests/test_tmp.hpp
+++ b/tests/test_tmp.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <unistd.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+
+// mkdtemp under $TMPDIR: unpredictable, owned 0700, safe in shared /tmp
+inline auto make_test_dir(const std::string &name) -> std::string {
+  const char *tmp = std::getenv("TMPDIR");
+  std::string templ = std::string(tmp != nullptr && *tmp != '\0' ? tmp : "/tmp") +
+                      "/" + name + ".XXXXXX";
+  if (mkdtemp(templ.data()) == nullptr) {
+    perror("mkdtemp");
+    std::abort();
+  }
+  static std::string created;
+  created = templ;
+  std::atexit([] { std::filesystem::remove_all(created); });
+  return templ;
+}


### PR DESCRIPTION
macOS lacks fdatasync; use fcntl(F_FULLFSYNC) there. Include <exception> in tree.cpp and fix a uint64_t printf format in bench.