### PR TITLE
plugin: port TarmacStore to the Nix 2.36 derivation API

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,0 +1,14 @@
+name: Auto Merge Dependency Updates
+on:
+  - pull_request_target
+jobs:
+  auto-merge-dependency-updates:
+    runs-on: ubuntu-slim
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: "auto-merge:${{ github.head_ref }}"
+      cancel-in-progress: true
+    steps:
+      - uses: Mic92/auto-merge@main

--- a/effects.nix
+++ b/effects.nix
@@ -1,0 +1,53 @@
+{ nixpkgs, nixbot }:
+_args:
+let
+  pkgs = nixpkgs.legacyPackages.x86_64-linux;
+  inherit (nixbot.lib.effects { inherit pkgs; }) mkEffect;
+in
+{
+  # Daily bump of nix-git.json so API breakage in Nix master shows up here
+  # before downstream flakes pull a newer nix. PRs carry the auto-merge label
+  # and land via .github/workflows/auto-merge.yaml once CI is green.
+  onSchedule.update-nix-git = {
+    when = {
+      hour = 4;
+      minute = 17;
+    };
+    outputs.effects.update-nix-git = mkEffect {
+      name = "effect-update-nix-git";
+      checkout = true;
+      inputs = [
+        pkgs.git
+        pkgs.gh
+        pkgs.nix
+        pkgs.jq
+      ];
+      secretsMap.git.type = "GitToken";
+      effectScript = ''
+        set -euo pipefail
+        export NIX_CONFIG="experimental-features = nix-command flakes"
+        GH_TOKEN=$(jq -r '.git.data.token' "$HERCULES_CI_SECRETS_JSON")
+        export GH_TOKEN
+        git config --global user.name "nix-tarmac-bot"
+        git config --global user.email "nix-tarmac-bot@users.noreply.github.com"
+        git config --global safe.directory '*'
+        cd "$NIXBOT_EFFECT_CHECKOUT"
+
+        ./scripts/update-nix-git.sh
+        if git diff --quiet nix-git.json; then
+          exit 0
+        fi
+        version=$(jq -r .version nix-git.json)
+        branch=update-nix-git
+        git checkout -b "$branch"
+        git commit -m "nix-git: bump to $version" nix-git.json
+        git push -f origin "$branch"
+        if ! gh pr view "$branch" --json state -q .state 2>/dev/null | grep -qx OPEN; then
+          gh pr create --head "$branch" --title "nix-git: bump to $version" \
+            --body "Automated bump of nix-git.json to current NixOS/nix master." \
+            --label auto-merge
+        fi
+      '';
+    };
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,28 @@
 {
   "nodes": {
+    "nixbot": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1787917367,
+        "narHash": "sha256-FCFmTnV7UQog1JWm0TvySlBnHBnyt+g6BlhUUFdE8SE=",
+        "ref": "main",
+        "rev": "660d7182cbabd2ca751d59d242c816d14038b0d1",
+        "shallow": true,
+        "type": "git",
+        "url": "https://github.com/Mic92/nixbot"
+      },
+      "original": {
+        "ref": "main",
+        "shallow": true,
+        "type": "git",
+        "url": "https://github.com/Mic92/nixbot"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1786963906,
@@ -18,7 +41,29 @@
     },
     "root": {
       "inputs": {
+        "nixbot": "nixbot",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixbot",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,9 +2,15 @@
   description = "Fast tarball fetcher cache plugin for Nix";
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.nixbot.url = "git+https://github.com/Mic92/nixbot?shallow=1&ref=main";
+  inputs.nixbot.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs =
-    { self, nixpkgs }:
+    {
+      self,
+      nixpkgs,
+      nixbot,
+    }:
     let
       systems = [
         "x86_64-linux"
@@ -52,6 +58,8 @@
         }
         // scope.versionPlugins
       );
+
+      herculesCI = import ./effects.nix { inherit nixpkgs nixbot; };
 
       nixosModules.default = tarmacModule;
       darwinModules.default = tarmacModule;

--- a/nix-git.json
+++ b/nix-git.json
@@ -1,0 +1,7 @@
+{
+  "owner": "NixOS",
+  "repo": "nix",
+  "rev": "7f711bef56d36a95946c2da95dc325fa65683da1",
+  "hash": "sha256-TVt/sYy1M+rLSMJ77k4vMwRsLz4CQc7Ueg+EemdBcdE=",
+  "version": "2.36.0pre20260828_7f711bef"
+}

--- a/packages.nix
+++ b/packages.nix
@@ -25,7 +25,7 @@ lib.makeScope newScope (
       ((nixVersions.nixComponents_git.overrideSource nixGitSrc).overrideScope (
         _final: _prev: { inherit (nixGitPin) version; }
       )).nix-everything;
-    libsFor = version: if version == "git" then nixGit.libs else nixVersions.${version}.libs;
+    nixFor = version: if version == "git" then nixGit else nixVersions.${version};
 
     supportedNixVersions = builtins.filter (
       name:
@@ -47,9 +47,15 @@ lib.makeScope newScope (
       map (
         version:
         lib.nameValuePair "plugin-${version}" (
-          self.callPackage ./package.nix {
-            inherit (libsFor version) nix-fetchers nix-store nix-util;
-          }
+          (self.callPackage ./package.nix {
+            inherit ((nixFor version).libs) nix-fetchers nix-store nix-util;
+          }).overrideAttrs
+            (old: {
+              # tests/e2e.sh runs the plugin under exactly this nix
+              passthru = (old.passthru or { }) // {
+                nix = nixFor version;
+              };
+            })
         )
       ) (supportedNixVersions ++ [ "git" ])
     );

--- a/packages.nix
+++ b/packages.nix
@@ -2,12 +2,31 @@
 {
   lib,
   newScope,
+  fetchFromGitHub,
   nixVersions,
   symlinkJoin,
 }:
 lib.makeScope newScope (
   self:
   let
+    # nixpkgs' nixVersions.git lags behind master; track it closer so API
+    # breakage shows up here before downstream flakes pull a newer nix.
+    # Bumped daily by the update-nix-git effect (effects.nix).
+    nixGitPin = lib.importJSON ./nix-git.json;
+    nixGitSrc = fetchFromGitHub {
+      inherit (nixGitPin)
+        owner
+        repo
+        rev
+        hash
+        ;
+    };
+    nixGit =
+      ((nixVersions.nixComponents_git.overrideSource nixGitSrc).overrideScope (
+        _final: _prev: { inherit (nixGitPin) version; }
+      )).nix-everything;
+    libsFor = version: if version == "git" then nixGit.libs else nixVersions.${version}.libs;
+
     supportedNixVersions = builtins.filter (
       name:
       builtins.match "nix_[0-9]+_[0-9]+" name != null
@@ -29,7 +48,7 @@ lib.makeScope newScope (
         version:
         lib.nameValuePair "plugin-${version}" (
           self.callPackage ./package.nix {
-            inherit (nixVersions.${version}.libs) nix-fetchers nix-store nix-util;
+            inherit (libsFor version) nix-fetchers nix-store nix-util;
           }
         )
       ) (supportedNixVersions ++ [ "git" ])

--- a/plugin/nix_compat.hh
+++ b/plugin/nix_compat.hh
@@ -1,0 +1,78 @@
+// Shims over Nix C++ API churn so the rest of the plugin has no version
+// conditionals. NIX_COMPAT_VERSION_* come from meson.
+#pragma once
+
+#include <nix/store/derivations.hh>
+#include <nix/store/path.hh>
+#include <nix/store/store-dir-config.hh>
+
+#include <string>
+#include <string_view>
+#include <utility>
+
+#define TARMAC_NIX_AT_LEAST(major, minor)                                      \
+  (NIX_COMPAT_VERSION_MAJOR > (major) ||                                       \
+   (NIX_COMPAT_VERSION_MAJOR == (major) &&                                     \
+    NIX_COMPAT_VERSION_MINOR >= (minor)))
+
+// Store / SourceAccessor grew an anchor() key function and the Store API
+// settled enough for TarmacStore.
+#define TARMAC_HAVE_STORE TARMAC_NIX_AT_LEAST(2, 35)
+
+#if TARMAC_NIX_AT_LEAST(2, 35)
+#define TARMAC_ANCHOR_OVERRIDE                                                 \
+  void anchor() override {}
+#else
+#define TARMAC_ANCHOR_OVERRIDE
+#endif
+
+// 2.36 split Derivation into a template over its inputs, moved the ATerm
+// (de)serialiser into nix::derivation and renamed the registerDrvOutput
+// hook to registerDrvOutputUnchecked.
+#if TARMAC_NIX_AT_LEAST(2, 36)
+#include <nix/store/derivation/aterm.hh>
+#define TARMAC_REGISTER_DRV_OUTPUT registerDrvOutputUnchecked
+#else
+#define TARMAC_REGISTER_DRV_OUTPUT registerDrvOutput
+#endif
+
+namespace nix_compat {
+
+#if TARMAC_HAVE_STORE
+inline auto parseDrv(const nix::StoreDirConfig &store, std::string &&text,
+                     std::string_view name) -> nix::Derivation {
+#if TARMAC_NIX_AT_LEAST(2, 36)
+  return nix::derivation::parse(store, std::move(text), name);
+#else
+  return nix::parseDerivation(store, std::move(text), name);
+#endif
+}
+
+inline auto unparseDrv(const nix::StoreDirConfig &store,
+                       const nix::Derivation &drv) -> std::string {
+#if TARMAC_NIX_AT_LEAST(2, 36)
+  return nix::derivation::unparse(drv, store, false);
+#else
+  return drv.unparse(store, false);
+#endif
+}
+
+// store paths a .drv refers to (input sources and input derivations)
+inline auto drvReferences(const nix::Derivation &drv) -> nix::StorePathSet {
+#if TARMAC_NIX_AT_LEAST(2, 36)
+  nix::StorePathSet refs;
+  for (const auto &input : drv.inputs) {
+    refs.insert(input.getBaseStorePath());
+  }
+  return refs;
+#else
+  auto refs = drv.inputSrcs;
+  for (const auto &[inputDrv, node] : drv.inputDrvs.map) {
+    refs.insert(inputDrv);
+  }
+  return refs;
+#endif
+}
+#endif
+
+} // namespace nix_compat

--- a/plugin/pack_accessor.hh
+++ b/plugin/pack_accessor.hh
@@ -3,6 +3,7 @@
 #ifndef NIX_TARMAC_PACK_ACCESSOR_HH
 #define NIX_TARMAC_PACK_ACCESSOR_HH
 
+#include "nix_compat.hh"
 #include "pack_cas.hpp"
 #include "tree.hpp"
 
@@ -38,10 +39,7 @@ public:
     fingerprint = "tarmac:" + to_hex(root_);
   }
 
-#if NIX_COMPAT_VERSION_MAJOR > 2 ||                                            \
-    (NIX_COMPAT_VERSION_MAJOR == 2 && NIX_COMPAT_VERSION_MINOR >= 35)
-  void anchor() override {}
-#endif
+  TARMAC_ANCHOR_OVERRIDE
 
   void readFile(const nix::CanonPath &path, nix::Sink &sink,
                 nix::fun<void(uint64_t)> sizeCallback) override {

--- a/plugin/store.cc
+++ b/plugin/store.cc
@@ -3,8 +3,8 @@
 // survives evaluator restarts, so store objects are written only once.
 // The store API churned before 2.35, older versions only get the
 // fetcher.
-#if NIX_COMPAT_VERSION_MAJOR > 2 ||                                            \
-    (NIX_COMPAT_VERSION_MAJOR == 2 && NIX_COMPAT_VERSION_MINOR >= 35)
+#include "nix_compat.hh"
+#if TARMAC_HAVE_STORE
 
 #include "ctx.hh"
 #include "pack_accessor.hh"
@@ -41,6 +41,10 @@
 #include <vector>
 
 namespace {
+
+using nix_compat::drvReferences;
+using nix_compat::parseDrv;
+using nix_compat::unparseDrv;
 
 constexpr std::string_view kPathPrefix = "sp:";
 constexpr std::string_view kDrvPrefix = "sd:";
@@ -312,12 +316,8 @@ struct TarmacStore : nix::Store {
     };
     // drv paths hash their references in, report them so a copy to
     // another store keeps the path
-    const auto drv = parseDerivation(*this, std::move(text),
-                                     nix::Derivation::nameFromPath(path));
-    info->references = drv.inputSrcs;
-    for (const auto &[inputDrv, node] : drv.inputDrvs.map) {
-      info->references.insert(inputDrv);
-    }
+    info->references = drvReferences(
+        parseDrv(*this, std::move(text), nix::Derivation::nameFromPath(path)));
     return info;
   }
 
@@ -416,9 +416,8 @@ struct TarmacStore : nix::Store {
     auto accessor =
         parseToMemory(source, nix::FileSerialisationMethod::NixArchive);
     if (info.path.isDerivation()) {
-      writeDerivation(parseDerivation(*this,
-                                      accessor->readFile(nix::CanonPath::root),
-                                      nix::Derivation::nameFromPath(info.path)),
+      writeDerivation(parseDrv(*this, accessor->readFile(nix::CanonPath::root),
+                               nix::Derivation::nameFromPath(info.path)),
                       nix::NoRepair);
     } else if (!pathRecord(info.path)) {
       storeObject(info, *accessor->root);
@@ -467,7 +466,7 @@ struct TarmacStore : nix::Store {
     auto drvPath = nix::computeStorePath(*this, drv);
     if (!drvText(drvPath)) {
       const std::scoped_lock lock(state->mutex);
-      const auto id = state->store.putBlob(drv.unparse(*this, false));
+      const auto id = state->store.putBlob(unparseDrv(*this, drv));
       state->store.registerRoot(id, false);
       metaPut(kDrvPrefix, drvPath, id);
       state->store.sync();
@@ -481,8 +480,8 @@ struct TarmacStore : nix::Store {
     if (!text) {
       throw nix::Error("derivation '%s' is not valid", printStorePath(drvPath));
     }
-    return parseDerivation(*this, std::move(*text),
-                           nix::Derivation::nameFromPath(drvPath));
+    return parseDrv(*this, std::move(*text),
+                    nix::Derivation::nameFromPath(drvPath));
   }
 
   auto readInvalidDerivation(const nix::StorePath &drvPath)
@@ -490,7 +489,8 @@ struct TarmacStore : nix::Store {
     return readDerivation(drvPath);
   }
 
-  void registerDrvOutput(const nix::Realisation & /*output*/) override {
+  void
+  TARMAC_REGISTER_DRV_OUTPUT(const nix::Realisation & /*output*/) override {
     unsupported("registerDrvOutput");
   }
 

--- a/scripts/update-nix-git.sh
+++ b/scripts/update-nix-git.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Bump nix-git.json to the latest NixOS/nix master commit.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+pin=nix-git.json
+
+owner=$(jq -r .owner "$pin")
+repo=$(jq -r .repo "$pin")
+old_rev=$(jq -r .rev "$pin")
+
+new_rev=$(git ls-remote "https://github.com/$owner/$repo" refs/heads/master | cut -f1)
+if [[ "$new_rev" == "$old_rev" ]]; then
+  echo "nix-git already at $new_rev"
+  exit 0
+fi
+
+prefetch=$(nix flake prefetch --json "github:$owner/$repo/$new_rev")
+hash=$(jq -r .hash <<<"$prefetch")
+store_path=$(jq -r .storePath <<<"$prefetch")
+last_modified=$(jq -r .locked.lastModified <<<"$prefetch")
+
+base_version=$(tr -d '\n' <"$store_path/.version")
+date=$(date -u -d "@$last_modified" +%Y%m%d)
+version="${base_version}pre${date}_${new_rev:0:8}"
+
+jq -n \
+  --arg owner "$owner" --arg repo "$repo" --arg rev "$new_rev" \
+  --arg hash "$hash" --arg version "$version" \
+  '{owner: $owner, repo: $repo, rev: $rev, hash: $hash, version: $version}' \
+  >"$pin.tmp"
+mv "$pin.tmp" "$pin"
+
+echo "nix-git: $old_rev -> $new_rev ($version)"

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -24,7 +24,7 @@ url="file://$work/src.tar.gz"
 expr="(builtins.fetchTree { type = \"tarball\"; url = \"$url\"; }).narHash"
 
 for v in $versions; do
-  nixbin=$(nix build --no-link --print-out-paths "nixpkgs#nixVersions.$v.out")/bin/nix
+  nixbin=$(nix build --no-link --print-out-paths "$repo#plugin-$v.nix.out")/bin/nix
   plugin=$(nix build --no-link --print-out-paths "$repo#plugin-$v")/lib/nix/plugins
   common=(--extra-experimental-features 'nix-command flakes' --impure --raw)
 
@@ -75,41 +75,45 @@ echo "OK degrade: builtin fallback on nix_2_31"
 
 # eval store: drvs land in the pack CAS, building copies them out to
 # the real store on demand
-nixbin=$(nix build --no-link --print-out-paths "nixpkgs#nixVersions.nix_2_35.out")/bin/nix
-plugin=$(nix build --no-link --print-out-paths "$repo#plugin-nix_2_35")/lib/nix/plugins
-export XDG_CACHE_HOME="$work/cache-evalstore"
-evalstore="tarmac://$work/evalstore"
-# a fresh salt keeps the drv out of /nix/store from earlier runs
-buildexpr="derivation {
-  name = \"tarmac-e2e-$RANDOM$RANDOM\";
-  system = builtins.currentSystem;
-  builder = \"/bin/sh\";
-  args = [ \"-c\" \"echo ok > \$out\" ];
-  note = builtins.toFile \"note.txt\" \"hello\";
-}"
-common=(--extra-experimental-features 'nix-command flakes' --impure
-  --plugin-files "$plugin" --eval-store "$evalstore")
+for v in $versions; do
+  # TarmacStore needs the >= 2.35 Store API
+  case $v in nix_2_3[0-4]) continue ;; esac
+  nixbin=$(nix build --no-link --print-out-paths "$repo#plugin-$v.nix.out")/bin/nix
+  plugin=$(nix build --no-link --print-out-paths "$repo#plugin-$v")/lib/nix/plugins
+  export XDG_CACHE_HOME="$work/cache-evalstore-$v"
+  evalstore="tarmac://$work/evalstore-$v"
+  # a fresh salt keeps the drv out of /nix/store from earlier runs
+  buildexpr="derivation {
+    name = \"tarmac-e2e-$RANDOM$RANDOM\";
+    system = builtins.currentSystem;
+    builder = \"/bin/sh\";
+    args = [ \"-c\" \"echo ok > \$out\" ];
+    note = builtins.toFile \"note.txt\" \"hello\";
+  }"
+  common=(--extra-experimental-features 'nix-command flakes' --impure
+    --plugin-files "$plugin" --eval-store "$evalstore")
 
-drv=$("$nixbin" eval "${common[@]}" --raw --expr "($buildexpr).drvPath")
-[[ -e $work/evalstore/pack.0 ]] || {
-  echo "FAIL evalstore: store not populated" >&2
-  exit 1
-}
-[[ -e $drv ]] && {
-  echo "FAIL evalstore: drv leaked into /nix/store" >&2
-  exit 1
-}
-# hash-part lookup must find the drv in the meta table
-found=$("$nixbin" store path-from-hash-part \
-  --extra-experimental-features 'nix-command flakes' \
-  --plugin-files "$plugin" --store "$evalstore" "${drv:11:32}")
-[[ $found == "$drv" ]] || {
-  echo "FAIL evalstore: queryPathFromHashPart" >&2
-  exit 1
-}
-out=$("$nixbin" build "${common[@]}" --no-link --print-out-paths --expr "$buildexpr")
-[[ $(cat "$out") == ok ]] || {
-  echo "FAIL evalstore: build output mismatch" >&2
-  exit 1
-}
-echo "OK evalstore: eval + build via $evalstore"
+  drv=$("$nixbin" eval "${common[@]}" --raw --expr "($buildexpr).drvPath")
+  [[ -e $work/evalstore-$v/pack.0 ]] || {
+    echo "FAIL evalstore $v: store not populated" >&2
+    exit 1
+  }
+  [[ -e $drv ]] && {
+    echo "FAIL evalstore $v: drv leaked into /nix/store" >&2
+    exit 1
+  }
+  # hash-part lookup must find the drv in the meta table
+  found=$("$nixbin" store path-from-hash-part \
+    --extra-experimental-features 'nix-command flakes' \
+    --plugin-files "$plugin" --store "$evalstore" "${drv:11:32}")
+  [[ $found == "$drv" ]] || {
+    echo "FAIL evalstore $v: queryPathFromHashPart" >&2
+    exit 1
+  }
+  out=$("$nixbin" build "${common[@]}" --no-link --print-out-paths --expr "$buildexpr")
+  [[ $(cat "$out") == ok ]] || {
+    echo "FAIL evalstore $v: build output mismatch" >&2
+    exit 1
+  }
+  echo "OK evalstore $v: eval + build via $evalstore"
+done


### PR DESCRIPTION

Derivation became a template, the ATerm (un)parser moved to
nix::derivation and registerDrvOutput was renamed. Version shims now
live in plugin/nix_compat.hh.
