### PR TITLE
nix-git: pin one commit behind master to exercise the updater

### DIFF
--- a/nix-git.json
+++ b/nix-git.json
@@ -1,7 +1,7 @@
 {
   "owner": "NixOS",
   "repo": "nix",
-  "rev": "7f711bef56d36a95946c2da95dc325fa65683da1",
-  "hash": "sha256-TVt/sYy1M+rLSMJ77k4vMwRsLz4CQc7Ueg+EemdBcdE=",
-  "version": "2.36.0pre20260828_7f711bef"
+  "rev": "df1878b6dd37ecc9360a5860ab5f90cee20ee5eb",
+  "hash": "sha256-aHQeWwfstVVdxOcmqJkv9QXqODmiyttH97M4ERaofw0=",
+  "version": "2.36.0pre20260828_df1878b6"
 }

--- a/packages.nix
+++ b/packages.nix
@@ -9,7 +9,7 @@
 lib.makeScope newScope (
   self:
   let
-    # nixpkgs' nixVersions.git lags behind master; track it closer so API
+    # nixpkgs' nixVersions.git lags behind master. Track it closer so API
     # breakage shows up here before downstream flakes pull a newer nix.
     # Bumped daily by the update-nix-git effect (effects.nix).
     nixGitPin = lib.importJSON ./nix-git.json;


### PR DESCRIPTION

Lets the first scheduled update-nix-git run produce a PR so the
effect and auto-merge path can be verified end to end.
