### PR TITLE
effects: drop the nixbot flake input

### DIFF
--- a/effects.nix
+++ b/effects.nix
@@ -1,8 +1,7 @@
-{ nixpkgs, nixbot }:
+{ nixpkgs }:
 _args:
 let
   pkgs = nixpkgs.legacyPackages.x86_64-linux;
-  inherit (nixbot.lib.effects { inherit pkgs; }) mkEffect;
 in
 {
   # Weekly bump of nix-git.json so API breakage in Nix master shows up here
@@ -14,41 +13,47 @@ in
       hour = 4;
       minute = 17;
     };
-    outputs.effects.update-nix-git = mkEffect {
-      name = "effect-update-nix-git";
-      checkout = true;
-      inputs = [
-        pkgs.git
-        pkgs.gh
-        pkgs.nix
-        pkgs.jq
-      ];
-      secretsMap.git.type = "GitToken";
-      effectScript = ''
-        set -euo pipefail
-        export NIX_CONFIG="experimental-features = nix-command flakes"
-        GH_TOKEN=$(jq -r '.git.data.token' "$HERCULES_CI_SECRETS_JSON")
-        export GH_TOKEN
-        git config --global user.name "nix-tarmac-bot"
-        git config --global user.email "nix-tarmac-bot@users.noreply.github.com"
-        git config --global safe.directory '*'
-        cd "$NIXBOT_EFFECT_CHECKOUT"
+    # Plain derivation instead of nixbot's mkEffect to avoid the flake input.
+    # nixbot reads secretsMap and __nixbot_effect_checkout, see its
+    # docs/EFFECTS.md.
+    outputs.effects.update-nix-git =
+      pkgs.runCommand "effect-update-nix-git"
+        {
+          nativeBuildInputs = [
+            pkgs.cacert
+            pkgs.git
+            pkgs.gh
+            pkgs.nix
+            pkgs.jq
+          ];
+          secretsMap = builtins.toJSON { git.type = "GitToken"; };
+          __nixbot_effect_checkout = true;
+        }
+        ''
+          export HOME=/build/home
+          mkdir -p "$HOME"
+          export NIX_CONFIG="experimental-features = nix-command flakes"
+          GH_TOKEN=$(jq -r '.git.data.token' "$HERCULES_CI_SECRETS_JSON")
+          export GH_TOKEN
+          git config --global user.name "nix-tarmac-bot"
+          git config --global user.email "nix-tarmac-bot@users.noreply.github.com"
+          git config --global safe.directory '*'
+          cd "$NIXBOT_EFFECT_CHECKOUT"
 
-        ./scripts/update-nix-git.sh
-        if git diff --quiet nix-git.json; then
-          exit 0
-        fi
-        version=$(jq -r .version nix-git.json)
-        branch=update-nix-git
-        git checkout -b "$branch"
-        git commit -m "nix-git: bump to $version" nix-git.json
-        git push -f origin "$branch"
-        if ! gh pr view "$branch" --json state -q .state 2>/dev/null | grep -qx OPEN; then
-          gh pr create --head "$branch" --title "nix-git: bump to $version" \
-            --body "Automated bump of nix-git.json to current NixOS/nix master." \
-            --label auto-merge
-        fi
-      '';
-    };
+          bash scripts/update-nix-git.sh
+          if git diff --quiet nix-git.json; then
+            exit 0
+          fi
+          version=$(jq -r .version nix-git.json)
+          branch=update-nix-git
+          git checkout -b "$branch"
+          git commit -m "nix-git: bump to $version" nix-git.json
+          git push -f origin "$branch"
+          if ! gh pr view "$branch" --json state -q .state 2>/dev/null | grep -qx OPEN; then
+            gh pr create --head "$branch" --title "nix-git: bump to $version" \
+              --body "Automated bump of nix-git.json to current NixOS/nix master." \
+              --label auto-merge
+          fi
+        '';
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -1,28 +1,5 @@
 {
   "nodes": {
-    "nixbot": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "treefmt-nix": "treefmt-nix"
-      },
-      "locked": {
-        "lastModified": 1787917367,
-        "narHash": "sha256-FCFmTnV7UQog1JWm0TvySlBnHBnyt+g6BlhUUFdE8SE=",
-        "ref": "main",
-        "rev": "660d7182cbabd2ca751d59d242c816d14038b0d1",
-        "shallow": true,
-        "type": "git",
-        "url": "https://github.com/Mic92/nixbot"
-      },
-      "original": {
-        "ref": "main",
-        "shallow": true,
-        "type": "git",
-        "url": "https://github.com/Mic92/nixbot"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1786963906,
@@ -41,29 +18,7 @@
     },
     "root": {
       "inputs": {
-        "nixbot": "nixbot",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "treefmt-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixbot",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1780220602,
-        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,15 +2,9 @@
   description = "Fast tarball fetcher cache plugin for Nix";
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-  inputs.nixbot.url = "git+https://github.com/Mic92/nixbot?shallow=1&ref=main";
-  inputs.nixbot.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs =
-    {
-      self,
-      nixpkgs,
-      nixbot,
-    }:
+    { self, nixpkgs }:
     let
       systems = [
         "x86_64-linux"
@@ -59,7 +53,7 @@
         // scope.versionPlugins
       );
 
-      herculesCI = import ./effects.nix { inherit nixpkgs nixbot; };
+      herculesCI = import ./effects.nix { inherit nixpkgs; };
 
       nixosModules.default = tarmacModule;
       darwinModules.default = tarmacModule;


### PR DESCRIPTION
The effect is a plain derivation with secretsMap and __nixbot_effect_checkout set, which is all nixbot reads. Saves every consumer of this flake a nixbot/treefmt-nix lock entry.