### PR TITLE
store: answer pathInfoIsUntrusted, so an eval store can be populated

### DIFF
--- a/plugin/store.cc
+++ b/plugin/store.cc
@@ -11,8 +11,12 @@
 #include "pack_cas.hpp"
 #include "tree.hpp"
 
+#include <mutex>
+
 #include <nix/store/content-address.hh>
 #include <nix/store/derivations.hh>
+#include <nix/store/globals.hh>
+#include <nix/store/keys.hh>
 #include <nix/store/path-info.hh>
 #include <nix/store/store-api.hh>
 #include <nix/store/store-registration.hh>
@@ -201,6 +205,11 @@ struct TarmacStoreConfig : std::enable_shared_from_this<TarmacStoreConfig>,
                            virtual nix::StoreConfig {
   std::string dir;
 
+  nix::Setting<bool> requireSigs{
+      this, nix::settings.requireSigs, "require-sigs",
+      "Whether store paths copied into this store should have a trusted "
+      "signature."};
+
   explicit TarmacStoreConfig(const Params &params)
       : StoreConfig(params, nix::StoreConfig::FilePathType::Unix),
         dir(Ctx::defaultDir()) {
@@ -246,11 +255,19 @@ struct TarmacStore : nix::Store {
 
   nix::ref<const Config> config;
   std::shared_ptr<Ctx> state;
+  std::once_flag publicKeysOnce;
+  nix::PublicKeys publicKeysCache;
 
   explicit TarmacStore(nix::ref<const Config> conf)
       : Store{*conf}, config(conf), state(Ctx::get(conf->dir)) {}
 
   void anchor() override {}
+
+  auto publicKeys() -> const nix::PublicKeys & {
+    std::call_once(publicKeysOnce,
+                   [this] { publicKeysCache = nix::getDefaultPublicKeys(); });
+    return publicKeysCache;
+  }
 
   auto metaKey(std::string_view prefix, const nix::StorePath &path)
       -> std::string {
@@ -363,6 +380,12 @@ struct TarmacStore : nix::Store {
 
   auto isTrustedClient() -> std::optional<nix::TrustedFlag> override {
     return nix::Trusted;
+  }
+
+  // the base Store calls every substitute untrusted, which leaves an
+  // --eval-store no way to fill itself
+  auto pathInfoIsUntrusted(const nix::ValidPathInfo &info) -> bool override {
+    return config->requireSigs && !info.checkSignatures(*this, publicKeys());
   }
 
   auto queryPathFromHashPart(const std::string &hashPart)


### PR DESCRIPTION
Substitution is how an `--eval-store` fills up, but nix checks
`dstStore.pathInfoIsUntrusted()` before it downloads anything, and the base
`Store` returns `true` unconditionally. `TarmacStore` inherited that, so every
substitute was dropped:

```
warning: ignoring substitute for '/nix/store/…' from 'https://…', as it's not
signed by any of the keys in 'trusted-public-keys'
```

even when the narinfo carried a signature the client trusts. The evaluation
then died on the first path it could not build itself:

```
error: path '/nix/store/…' is required, but there is no substituter that can
build it
```

A chroot local store in the same role works, which made this look like an
eval-store limitation rather than a store-specific one. It bites any
evaluation that reads substitute-only store paths — in my case a NixOS system
whose package set pins parts of its bootstrap by store path.

The fix answers the question the way `LocalStore` does: a per-store
`require-sigs`, defaulted from the global setting, checked against the default
public keys. `tarmac://?require-sigs=false` works as a result too.

### Testing

Evaluating a full NixOS system, eval cache off, against a **completely
unseeded** `tarmac://`:

| | before | after |
|---|---|---|
| unseeded eval store | fails | cold 30.0s, warm 4.8s |
| same eval in /nix/store | 7.4s | 7.4s |

Built and run against `nixVersions.git` at 2.35pre only — I have not exercised
the rest of the dispatcher's version matrix.